### PR TITLE
Fixing the Unit test which were failing of asset loading.

### DIFF
--- a/src/test/java/org/terasology/namegenerator/CreatureNameGeneratorSystemTest.java
+++ b/src/test/java/org/terasology/namegenerator/CreatureNameGeneratorSystemTest.java
@@ -16,12 +16,9 @@
 
 package org.terasology.namegenerator;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.terasology.HeadlessEnvironment;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.entity.internal.EngineEntityManager;
 import org.terasology.entitySystem.entity.lifecycleEvents.OnAddedComponent;
@@ -29,34 +26,15 @@ import org.terasology.logic.common.DisplayNameComponent;
 import org.terasology.namegenerator.creature.CreatureNameComponent;
 import org.terasology.namegenerator.creature.CreatureNameGeneratorComponent;
 import org.terasology.namegenerator.creature.CreatureNameGeneratorSystem;
-import org.terasology.naming.Name;
 import org.terasology.registry.CoreRegistry;
 
 /**
  * Tests {@link CreatureNameGeneratorSystem}
  */
-public class CreatureNameGeneratorSystemTest {
-
-    private static HeadlessEnvironment env;
+public class CreatureNameGeneratorSystemTest extends NameGeneratorTestingEnvironment {
 
     private static final Logger logger = LoggerFactory.getLogger(CreatureNameGeneratorSystemTest.class);
 
-    /**
-     * Setup headless environment
-     */
-    @BeforeClass
-    public static void setUpClass() {
-        env = new HeadlessEnvironment(new Name("NameGenerator"));
-    }
-
-    /**
-     * Clean up
-     * @throws Exception never
-     */
-    @AfterClass
-    public static void tearDownClass() throws Exception {
-        env.close();
-    }
 
     @Test
     public void test() {

--- a/src/test/java/org/terasology/namegenerator/NameGeneratorTestingEnvironment.java
+++ b/src/test/java/org/terasology/namegenerator/NameGeneratorTestingEnvironment.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2016 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.namegenerator;
+
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.terasology.HeadlessEnvironment;
+import org.terasology.assets.AssetFactory;
+import org.terasology.assets.management.AssetManager;
+import org.terasology.assets.module.ModuleAwareAssetTypeManager;
+import org.terasology.context.Context;
+import org.terasology.engine.module.ModuleManager;
+import org.terasology.entitySystem.metadata.ComponentLibrary;
+import org.terasology.entitySystem.prefab.Prefab;
+import org.terasology.entitySystem.prefab.PrefabData;
+import org.terasology.entitySystem.prefab.internal.PojoPrefab;
+import org.terasology.entitySystem.prefab.internal.PrefabFormat;
+import org.terasology.naming.Name;
+import org.terasology.persistence.typeHandling.TypeSerializationLibrary;
+
+public class NameGeneratorTestingEnvironment {
+    private static HeadlessEnvironment env;
+
+    /**
+     * Setup headless environment
+     */
+    @BeforeClass
+    public static void setUpClass() {
+        env = new HeadlessEnvironment(new Name("NameGenerator"));
+
+        Context context = env.getContext();
+        ModuleManager moduleManager = context.get(ModuleManager.class);
+
+        // Taken from: org.terasology.TerasologyTestingEnvironment
+        ModuleAwareAssetTypeManager assetTypeManager = new ModuleAwareAssetTypeManager();
+        assetTypeManager.registerCoreAssetType(Prefab.class,
+                (AssetFactory<Prefab, PrefabData>) PojoPrefab::new, "prefabs");
+
+        ComponentLibrary componentLibrary = context.get(ComponentLibrary.class);
+        TypeSerializationLibrary typeSerializationLibrary = context.get(TypeSerializationLibrary.class);
+        PrefabFormat prefabFormat = new PrefabFormat(componentLibrary, typeSerializationLibrary);
+        assetTypeManager.registerCoreFormat(Prefab.class, prefabFormat);
+
+        assetTypeManager.switchEnvironment(moduleManager.getEnvironment());
+        context.put(AssetManager.class, assetTypeManager.getAssetManager());
+    }
+
+    /**
+     * Clean up
+     * @throws Exception never
+     */
+    @AfterClass
+    public static void tearDownClass() throws Exception {
+        env.close();
+    }
+}

--- a/src/test/java/org/terasology/namegenerator/RegionNameProviderTest.java
+++ b/src/test/java/org/terasology/namegenerator/RegionNameProviderTest.java
@@ -18,43 +18,20 @@ package org.terasology.namegenerator;
 
 import static org.junit.Assert.assertFalse;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+
 import org.junit.Test;
-import org.terasology.HeadlessEnvironment;
 import org.terasology.namegenerator.region.RegionNameProvider;
-import org.terasology.naming.Name;
 
 /**
  * Tests {@link RegionNameProvider}
  */
-public class RegionNameProviderTest {
-
-    private static HeadlessEnvironment env;
-
-    /**
-     * Setup headless environment
-     */
-    @BeforeClass
-    public static void setUpClass() {
-        env = new HeadlessEnvironment(new Name("NameGenerator"));
-    }
-
-    /**
-     * Clean up
-     * @throws Exception never
-     */
-    @AfterClass
-    public static void tearDownClass() throws Exception {
-        env.close();
-    }
+public class RegionNameProviderTest extends NameGeneratorTestingEnvironment {
 
     /**
      * Requires that original training data names do <b>NOT</b> contain any spaces
      */
     @Test
     public void testBase() {
-
         RegionNameProvider prov = new RegionNameProvider(123455);
 
         for (int i = 0; i < 100; i++) {

--- a/src/test/java/org/terasology/namegenerator/TownNameProviderTest.java
+++ b/src/test/java/org/terasology/namegenerator/TownNameProviderTest.java
@@ -16,42 +16,21 @@
 
 package org.terasology.namegenerator;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.terasology.HeadlessEnvironment;
 import org.terasology.namegenerator.town.TownAffinityVector;
 import org.terasology.namegenerator.town.TownNameProvider;
-import org.terasology.naming.Name;
+
 
 import static org.junit.Assert.*;
 
 /**
  * Tests {@link TownNameProvider}
  */
-public class TownNameProviderTest {
+public class TownNameProviderTest extends NameGeneratorTestingEnvironment {
 
     private static final Logger logger = LoggerFactory.getLogger(TownNameProviderTest.class);
-    private static HeadlessEnvironment env;
-
-    /**
-     * Setup headless environment
-     */
-    @BeforeClass
-    public static void setUpClass() {
-        env = new HeadlessEnvironment(new Name("NameGenerator"));
-    }
-
-    /**
-     * Clean up
-     * @throws Exception never
-     */
-    @AfterClass
-    public static void tearDownClass() throws Exception {
-        env.close();
-    }
 
     /**
      * Requires that original training data names do <b>NOT</b> contain any spaces

--- a/src/test/java/org/terasology/namegenerator/WaterNameProviderTest.java
+++ b/src/test/java/org/terasology/namegenerator/WaterNameProviderTest.java
@@ -18,36 +18,14 @@ package org.terasology.namegenerator;
 
 import static org.junit.Assert.assertFalse;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+
 import org.junit.Test;
-import org.terasology.HeadlessEnvironment;
 import org.terasology.namegenerator.waters.WaterNameProvider;
-import org.terasology.naming.Name;
 
 /**
  * Tests {@link WaterNameProvider}
  */
-public class WaterNameProviderTest {
-
-    private static HeadlessEnvironment env;
-
-    /**
-     * Setup headless environment
-     */
-    @BeforeClass
-    public static void setUpClass() {
-        env = new HeadlessEnvironment(new Name("NameGenerator"));
-    }
-
-    /**
-     * Clean up
-     * @throws Exception never
-     */
-    @AfterClass
-    public static void tearDownClass() throws Exception {
-        env.close();
-    }
+public class WaterNameProviderTest extends NameGeneratorTestingEnvironment {
 
     /**
      * A very simple test


### PR DESCRIPTION
So I was looking into the failing unit tests and this is what I came up with to fix them. 

The initial problem was that the module's assets/prefabs could not be loaded, which obviously let the tests fail. I think the idea before was that the `HeadlessEnvironment` would set up everything required to run the tests in the module, complete with loading prefabs and such. 

I found [`TerasologyTestingEnvironment`](https://github.com/MovingBlocks/Terasology/blob/develop/engine-tests/src/main/java/org/terasology/TerasologyTestingEnvironment.java) and copied some of its intialization code. In particular, `assetTypeManager.registerCoreFormat(Prefab.class, prefabFormat);` and the related code differs from the implementation in `HeadlessEnvironment`.

I'd like to understand why these changes enable proper prefab loading in the unit tests. Should this behavior be supplied by `HeadlessEnvironment` itself, or is it up to it's users to set up the format. Pinging @flo  @msteiger @Immortius @Cervator 