### PR TITLE
replace Dependencies annotation with IntegrationEnvironment

### DIFF
--- a/src/test/java/org/terasology/namegenerator/CreatureNameGeneratorSystemTest.java
+++ b/src/test/java/org/terasology/namegenerator/CreatureNameGeneratorSystemTest.java
@@ -10,7 +10,7 @@ import org.slf4j.LoggerFactory;
 import org.terasology.engine.entitySystem.entity.EntityRef;
 import org.terasology.engine.entitySystem.entity.internal.EngineEntityManager;
 import org.terasology.engine.entitySystem.entity.lifecycleEvents.OnAddedComponent;
-import org.terasology.engine.integrationenvironment.jupiter.Dependencies;
+import org.terasology.engine.integrationenvironment.jupiter.IntegrationEnvironment;
 import org.terasology.engine.integrationenvironment.jupiter.MTEExtension;
 import org.terasology.engine.logic.common.DisplayNameComponent;
 import org.terasology.engine.registry.In;
@@ -22,7 +22,7 @@ import org.terasology.namegenerator.creature.CreatureNameGeneratorSystem;
  * Tests {@link CreatureNameGeneratorSystem}
  */
 @ExtendWith(MTEExtension.class)
-@Dependencies("NameGenerator")
+@IntegrationEnvironment(dependencies = "NameGenerator")
 @Tag("MteTest")
 public class CreatureNameGeneratorSystemTest {
 

--- a/src/test/java/org/terasology/namegenerator/CreatureNameProviderTest.java
+++ b/src/test/java/org/terasology/namegenerator/CreatureNameProviderTest.java
@@ -6,7 +6,7 @@ package org.terasology.namegenerator;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.terasology.engine.integrationenvironment.jupiter.Dependencies;
+import org.terasology.engine.integrationenvironment.jupiter.IntegrationEnvironment;
 import org.terasology.engine.integrationenvironment.jupiter.MTEExtension;
 import org.terasology.namegenerator.creature.CreatureAffinityVector;
 import org.terasology.namegenerator.creature.CreatureNameProvider;
@@ -18,7 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 @Tag("MteTest")
 @ExtendWith(MTEExtension.class)
-@Dependencies("NameGenerator")
+@IntegrationEnvironment(dependencies = "NameGenerator")
 public class CreatureNameProviderTest {
 
     /**

--- a/src/test/java/org/terasology/namegenerator/RegionNameProviderTest.java
+++ b/src/test/java/org/terasology/namegenerator/RegionNameProviderTest.java
@@ -5,7 +5,7 @@ package org.terasology.namegenerator;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.terasology.engine.integrationenvironment.jupiter.Dependencies;
+import org.terasology.engine.integrationenvironment.jupiter.IntegrationEnvironment;
 import org.terasology.engine.integrationenvironment.jupiter.MTEExtension;
 import org.terasology.namegenerator.region.RegionNameProvider;
 
@@ -16,7 +16,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
  */
 @Tag("MteTest")
 @ExtendWith(MTEExtension.class)
-@Dependencies("NameGenerator")
+@IntegrationEnvironment(dependencies = "NameGenerator")
 public class RegionNameProviderTest {
 
     /**

--- a/src/test/java/org/terasology/namegenerator/TownNameProviderTest.java
+++ b/src/test/java/org/terasology/namegenerator/TownNameProviderTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.terasology.engine.integrationenvironment.jupiter.Dependencies;
+import org.terasology.engine.integrationenvironment.jupiter.IntegrationEnvironment;
 import org.terasology.engine.integrationenvironment.jupiter.MTEExtension;
 import org.terasology.namegenerator.town.TownAffinityVector;
 import org.terasology.namegenerator.town.TownNameProvider;
@@ -22,7 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 @Tag("MteTest")
 @ExtendWith(MTEExtension.class)
-@Dependencies("NameGenerator")
+@IntegrationEnvironment(dependencies = "NameGenerator")
 public class TownNameProviderTest {
 
     private static final Logger logger = LoggerFactory.getLogger(TownNameProviderTest.class);

--- a/src/test/java/org/terasology/namegenerator/WaterNameProviderTest.java
+++ b/src/test/java/org/terasology/namegenerator/WaterNameProviderTest.java
@@ -5,7 +5,7 @@ package org.terasology.namegenerator;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.terasology.engine.integrationenvironment.jupiter.Dependencies;
+import org.terasology.engine.integrationenvironment.jupiter.IntegrationEnvironment;
 import org.terasology.engine.integrationenvironment.jupiter.MTEExtension;
 import org.terasology.namegenerator.waters.WaterNameProvider;
 
@@ -16,7 +16,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
  */
 @Tag("MteTest")
 @ExtendWith(MTEExtension.class)
-@Dependencies("NameGenerator")
+@IntegrationEnvironment(dependencies = "NameGenerator")
 public class WaterNameProviderTest {
 
     /**


### PR DESCRIPTION
I replaced the annotation Dependencies in CreatureNameGeneratorSystemTest, CreatureNameProviderTest, RegionNameProviderTest, TownNameProviderTest, WaterNameProviderTest

For more information, see <a href="https://github.com/MovingBlocks/Terasology/issues/5087">#5087<a/>