### PR TITLE
Reformatting annotations of ``NameGenerator``

### DIFF
--- a/src/test/java/org/terasology/namegenerator/CreatureNameGeneratorSystemTest.java
+++ b/src/test/java/org/terasology/namegenerator/CreatureNameGeneratorSystemTest.java
@@ -2,28 +2,23 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.namegenerator;
 
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.engine.entitySystem.entity.EntityRef;
 import org.terasology.engine.entitySystem.entity.internal.EngineEntityManager;
 import org.terasology.engine.entitySystem.entity.lifecycleEvents.OnAddedComponent;
-import org.terasology.engine.integrationenvironment.jupiter.Dependencies;
-import org.terasology.engine.integrationenvironment.jupiter.MTEExtension;
 import org.terasology.engine.logic.common.DisplayNameComponent;
 import org.terasology.engine.registry.In;
 import org.terasology.namegenerator.creature.CreatureNameComponent;
 import org.terasology.namegenerator.creature.CreatureNameGeneratorComponent;
 import org.terasology.namegenerator.creature.CreatureNameGeneratorSystem;
+import org.terasology.engine.integrationenvironment.jupiter.IntegrationEnvironment;
 
 /**
  * Tests {@link CreatureNameGeneratorSystem}
  */
-@ExtendWith(MTEExtension.class)
-@Dependencies("NameGenerator")
-@Tag("MteTest")
+@IntegrationEnvironment(dependencies = {"NameGenerator"})
 public class CreatureNameGeneratorSystemTest {
 
     private static final Logger logger = LoggerFactory.getLogger(CreatureNameGeneratorSystemTest.class);

--- a/src/test/java/org/terasology/namegenerator/CreatureNameProviderTest.java
+++ b/src/test/java/org/terasology/namegenerator/CreatureNameProviderTest.java
@@ -3,22 +3,17 @@
 
 package org.terasology.namegenerator;
 
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.terasology.engine.integrationenvironment.jupiter.Dependencies;
-import org.terasology.engine.integrationenvironment.jupiter.MTEExtension;
 import org.terasology.namegenerator.creature.CreatureAffinityVector;
 import org.terasology.namegenerator.creature.CreatureNameProvider;
+import org.terasology.engine.integrationenvironment.jupiter.IntegrationEnvironment;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests {@link CreatureNameProvider}
  */
-@Tag("MteTest")
-@ExtendWith(MTEExtension.class)
-@Dependencies("NameGenerator")
+@IntegrationEnvironment(dependencies = {"NameGenerator"})
 public class CreatureNameProviderTest {
 
     /**

--- a/src/test/java/org/terasology/namegenerator/RegionNameProviderTest.java
+++ b/src/test/java/org/terasology/namegenerator/RegionNameProviderTest.java
@@ -2,21 +2,16 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.namegenerator;
 
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.terasology.engine.integrationenvironment.jupiter.Dependencies;
-import org.terasology.engine.integrationenvironment.jupiter.MTEExtension;
 import org.terasology.namegenerator.region.RegionNameProvider;
+import org.terasology.engine.integrationenvironment.jupiter.IntegrationEnvironment;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * Tests {@link RegionNameProvider}
  */
-@Tag("MteTest")
-@ExtendWith(MTEExtension.class)
-@Dependencies("NameGenerator")
+@IntegrationEnvironment(dependencies = {"NameGenerator"})
 public class RegionNameProviderTest {
 
     /**

--- a/src/test/java/org/terasology/namegenerator/TownNameProviderTest.java
+++ b/src/test/java/org/terasology/namegenerator/TownNameProviderTest.java
@@ -3,15 +3,12 @@
 
 package org.terasology.namegenerator;
 
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.terasology.engine.integrationenvironment.jupiter.Dependencies;
-import org.terasology.engine.integrationenvironment.jupiter.MTEExtension;
 import org.terasology.namegenerator.town.TownAffinityVector;
 import org.terasology.namegenerator.town.TownNameProvider;
+import org.terasology.engine.integrationenvironment.jupiter.IntegrationEnvironment;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -20,9 +17,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * Tests {@link TownNameProvider}
  */
-@Tag("MteTest")
-@ExtendWith(MTEExtension.class)
-@Dependencies("NameGenerator")
+@IntegrationEnvironment(dependencies = {"NameGenerator"})
 public class TownNameProviderTest {
 
     private static final Logger logger = LoggerFactory.getLogger(TownNameProviderTest.class);

--- a/src/test/java/org/terasology/namegenerator/WaterNameProviderTest.java
+++ b/src/test/java/org/terasology/namegenerator/WaterNameProviderTest.java
@@ -2,21 +2,16 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.namegenerator;
 
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.terasology.engine.integrationenvironment.jupiter.Dependencies;
-import org.terasology.engine.integrationenvironment.jupiter.MTEExtension;
 import org.terasology.namegenerator.waters.WaterNameProvider;
+import org.terasology.engine.integrationenvironment.jupiter.IntegrationEnvironment;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * Tests {@link WaterNameProvider}
  */
-@Tag("MteTest")
-@ExtendWith(MTEExtension.class)
-@Dependencies("NameGenerator")
+@IntegrationEnvironment(dependencies = {"NameGenerator"})
 public class WaterNameProviderTest {
 
     /**


### PR DESCRIPTION
Related issue: [#5087](https://github.com/MovingBlocks/Terasology/issues/5087)

The goal of this PR is to replace old annotations in ``WaterNameProviderTest``, ``TownNameProviderTest``, ``RegionNameProviderTest``, ``CreatureNameProviderTest`` and ``CreatureNameGeneratorSystemTest``